### PR TITLE
Test Nightwatch in workflows

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -16,7 +16,7 @@ composer_version: "2"
 hooks:
   post-start:
     - exec: cd .. && composer install
-    - exec: cd core && yarn install
+    - exec: yarn install --non-interactive --cwd /var/www/html/web/core
     - exec: mkdir -p private/browsertest_output
 
 # This config.yaml was created with ddev version v1.16.7

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,4 +1,4 @@
-name: nightwatch-training
+name: drupal-testing-workshop
 type: drupal9
 docroot: web
 php_version: "7.3"

--- a/.ddev/docker-compose.testing.yaml
+++ b/.ddev/docker-compose.testing.yaml
@@ -27,6 +27,6 @@ services:
       DRUPAL_TEST_WEBDRIVER_HOSTNAME: chromedriver
       DRUPAL_TEST_WEBDRIVER_PORT: 9515
       DRUPAL_TEST_CHROMEDRIVER_AUTOSTART: 'true'
-      DRUPAL_TEST_WEBDRIVER_CHROME_ARGS: "--disable-gpu --headless"
+      DRUPAL_TEST_WEBDRIVER_CHROME_ARGS: "--disable-gpu --headless --no-sandbox"
       DRUPAL_NIGHTWATCH_OUTPUT: reports/nightwatch
       DRUPAL_NIGHTWATCH_IGNORE_DIRECTORIES: node_modules,vendor,.*,sites/*/files,sites/*/private,sites/simpletest

--- a/.github/workflows/ddev.yml
+++ b/.github/workflows/ddev.yml
@@ -13,3 +13,5 @@ jobs:
       - uses: jonaseberle/github-action-setup-ddev@v1
       - run: ddev phpunit core/modules/action --debug
       - run: ddev nightwatch --tag quicklink
+      - run: ddev logs -s chromedriver
+        if: ${{ failure() }}

--- a/.github/workflows/ddev.yml
+++ b/.github/workflows/ddev.yml
@@ -12,3 +12,4 @@ jobs:
       - uses: actions/checkout@v1
       - uses: jonaseberle/github-action-setup-ddev@v1
       - run: ddev phpunit core/modules/action --debug
+      - run: ddev nightwatch --tag quicklink

--- a/.github/workflows/lando.yml
+++ b/.github/workflows/lando.yml
@@ -15,3 +15,5 @@ jobs:
       - run: lando start
       - run: lando phpunit core/modules/action --debug
       - run: lando nightwatch --tag quicklink
+      - run: lando logs -s chromedriver
+        if: ${{ failure() }}

--- a/.github/workflows/lando.yml
+++ b/.github/workflows/lando.yml
@@ -14,3 +14,4 @@ jobs:
       - run: sudo dpkg -i --ignore-depends=docker-ce lando-stable.deb
       - run: lando start
       - run: lando phpunit core/modules/action --debug
+      - run: lando nightwatch --tag quicklink

--- a/.lando.yml
+++ b/.lando.yml
@@ -23,6 +23,8 @@ services:
   # to appserver. But having `socket hang up` errors.
   node:
     type: node:12
+    build:
+      - yarn install
     overrides:
       environment:
         # Nightwatch
@@ -37,7 +39,7 @@ services:
   chromedriver:
     type: compose
     services:
-      image: drupalci/webdriver-chromedriver:production
+      image: drupalci/chromedriver:production
       # Lando always overrides the default entrypoint.
       command: chromedriver --log-path=/tmp/chromedriver.log --verbose --whitelisted-ips=
 tooling:

--- a/.lando.yml
+++ b/.lando.yml
@@ -41,7 +41,7 @@ services:
     services:
       image: drupalci/chromedriver:production
       # Lando always overrides the default entrypoint.
-      command: chromedriver --log-path=/tmp/chromedriver.log --verbose --whitelisted-ips=
+      command: chromedriver --verbose --whitelisted-ips=
 tooling:
   phpunit:
     service: appserver

--- a/.lando.yml
+++ b/.lando.yml
@@ -24,7 +24,7 @@ services:
   node:
     type: node:12
     build:
-      - yarn install
+      - yarn install --non-interactive --cwd /app/web/core
     overrides:
       environment:
         # Nightwatch

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,13 +1,20 @@
-name: nightwatch-training
+name: drupal-testing-workshop
 recipe: drupal9
 config:
   webroot: web
   composer_version: 2
 services:
   appserver:
+    build_as_root:
+      # Note that you will want to use the script for the major version of node you want to install
+      # See: https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions
+      - curl -sL https://deb.nodesource.com/setup_12.x | bash -
+      - apt-get install -y nodejs
+      - npm install --global yarn
     build:
       - composer install
       - mkdir -p private/browsertest_output
+      - yarn install --non-interactive --cwd /app/web/core
     overrides:
       environment:
         # PHPUnit
@@ -19,21 +26,14 @@ services:
         # like have this read from $LANDO_DOMAIN
         BROWSERTEST_OUTPUT_BASE_URL: https://nightwatch-training.lndo.site/
         MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox"]}}, "http://chromedriver:9515"]'
-  # @todo this will break since there is no PHP, probably need to add Node + Yarn
-  # to appserver. But having `socket hang up` errors.
-  node:
-    type: node:12
-    build:
-      - yarn install --non-interactive --cwd /app/web/core
-    overrides:
-      environment:
+
         # Nightwatch
         DRUPAL_TEST_BASE_URL: 'http://appserver'
         DRUPAL_TEST_DB_URL: 'mysql://drupal9:drupal9@database:3306/drupal9'
         DRUPAL_TEST_WEBDRIVER_HOSTNAME: chromedriver
         DRUPAL_TEST_WEBDRIVER_PORT: 9515
         DRUPAL_TEST_CHROMEDRIVER_AUTOSTART: 'false'
-        DRUPAL_TEST_WEBDRIVER_CHROME_ARGS: "--disable-gpu --headless"
+        DRUPAL_TEST_WEBDRIVER_CHROME_ARGS: "--disable-gpu --headless --no-sandbox"
         DRUPAL_NIGHTWATCH_OUTPUT: reports/nightwatch
         DRUPAL_NIGHTWATCH_IGNORE_DIRECTORIES: node_modules,vendor,.*,sites/*/files,sites/*/private,sites/simpletest
   chromedriver:
@@ -49,10 +49,7 @@ tooling:
     cmd: php /app/vendor/bin/phpunit -c core/phpunit.xml.dist
     dir: /app/web
   nightwatch:
-    service: node
+    service: appserver
     description: Run Nightwatch.js
     cmd: yarn test:nightwatch
     dir: /app/web/core
-events:
-  post-start:
-    - appserver: mkdir -p private/browsertest_output


### PR DESCRIPTION
Having this problem with a Dockerized chromedriver instance, which didn't happen before.

```
[Tests/Integration Test] Test Suite
===================================
- Connecting to chromedriver on port 9515...

    POST http://chromedriver:9515 /session - ECONNRESET
Error: socket hang up
    at connResetException (internal/errors.js:607:14)
⚠ Error connecting to chromedriver on port 9515.
_________________________________________________

TEST FAILURE: 1 error during execution; 0 tests failed, 0 passed (1m 0s)
  Error: An error occurred while retrieving a new session: "socket hang up"
```

![Screen Shot 2021-03-22 at 12 05 05 PM](https://user-images.githubusercontent.com/3698644/112029122-e69c4e00-8b06-11eb-88e2-b7f271b1f19a.png)
